### PR TITLE
feat: add quantity and ftype to BOM rows; update CSV output and tests

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -77,6 +77,7 @@ describe("convertBomRowsToCsv", () => {
         comment: "1k",
         value: "1k",
         footprint: "0805",
+        quantity: 1,
         supplier_part_number_columns: {
           "JLCPCB Part #": "C17513",
         },
@@ -87,7 +88,7 @@ describe("convertBomRowsToCsv", () => {
 
     expect(csv).toMatchInlineSnapshot(`
       "Designator,Comment,Value,Footprint,Quantity,JLCPCB Part #
-      R1,1k,1k,0805,,C17513"
+      R1,1k,1k,0805,1,C17513"
     `)
   })
 })

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -31,6 +31,8 @@ describe("convertCircuitJsonToBomRows", () => {
       comment: "1k",
       value: "1k",
       footprint: "",
+      quantity: 1,
+      ftype: "simple_resistor",
     })
   })
 
@@ -61,8 +63,8 @@ describe("convertCircuitJsonToBomRows", () => {
     const bomRowsFromJson = await convertCircuitJsonToBomRows({ circuitJson })
     const csv = convertBomRowsToCsv(bomRowsFromJson)
     expect(csv).toMatchInlineSnapshot(`
-      "Designator,Comment,Value,Footprint,JLCPCB Part #
-      C1,10µ,10µ,,C12345"
+      "Designator,Comment,Value,Footprint,Quantity,JLCPCB Part #
+      C1,10µ,10µ,,1,C12345"
     `)
   })
 })
@@ -84,8 +86,8 @@ describe("convertBomRowsToCsv", () => {
     const csv = convertBomRowsToCsv(bomRows)
 
     expect(csv).toMatchInlineSnapshot(`
-      "Designator,Comment,Value,Footprint,JLCPCB Part #
-      R1,1k,1k,0805,C17513"
+      "Designator,Comment,Value,Footprint,Quantity,JLCPCB Part #
+      R1,1k,1k,0805,,C17513"
     `)
   })
 })

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -161,24 +161,25 @@ function si(v: string | number | undefined | null) {
 }
 
 export const convertBomRowsToCsv = (bom_rows: BomRow[]): string => {
-  const csv_data = bom_rows.map((row) => {
-    const supplier_part_number_columns = row.supplier_part_number_columns
-    const supplier_part_numbers = Object.values(
-      supplier_part_number_columns || {},
-    ).join(", ")
-    const extraColumns = Object.entries(row.extra_columns || {})
-      .map(([key, value]) => `${key}: ${value}`)
-      .join(", ")
+  const csv_data: Array<Record<string, string | number | undefined>> =
+    bom_rows.map((row) => {
+      const supplier_part_number_columns = row.supplier_part_number_columns
+      const supplier_part_numbers = Object.values(
+        supplier_part_number_columns || {},
+      ).join(", ")
+      const extraColumns = Object.entries(row.extra_columns || {})
+        .map(([key, value]) => `${key}: ${value}`)
+        .join(", ")
 
-    return {
-      Designator: row.designator,
-      Comment: row.comment,
-      Value: row.value,
-      Footprint: row.footprint,
-      Quantity: row.quantity,
-      ...supplier_part_number_columns,
-    }
-  })
+      return {
+        Designator: row.designator,
+        Comment: row.comment,
+        Value: row.value,
+        Footprint: row.footprint,
+        Quantity: row.quantity,
+        ...supplier_part_number_columns,
+      }
+    })
 
   const columnHeaders: string[] = [
     "Designator",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -99,39 +99,7 @@ export const convertCircuitJsonToBomRows = async ({
     })
   }
 
-  // Group identical components
-  const groupedBom: BomRow[] = []
-  const groupMap = new Map<string, BomRow[]>()
-
-  for (const row of bom) {
-    const key = JSON.stringify({
-      comment: row.comment,
-      value: row.value,
-      footprint: row.footprint,
-      ftype: row.ftype,
-      supplier_part_number_columns: row.supplier_part_number_columns,
-      manufacturer_mpn_pairs: row.manufacturer_mpn_pairs,
-      extra_columns: row.extra_columns,
-    })
-
-    if (!groupMap.has(key)) {
-      groupMap.set(key, [])
-    }
-    groupMap.get(key)!.push(row)
-  }
-
-  for (const group of groupMap.values()) {
-    const first = group[0]
-    const designators = group.map((r) => r.designator).sort()
-    const designator = designators.join(",")
-    groupedBom.push({
-      ...first,
-      designator,
-      quantity: group.length,
-    })
-  }
-
-  return groupedBom
+  return bom
 }
 
 function convertSupplierPartNumbersIntoColumns(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,6 +18,8 @@ interface BomRow {
   comment: string
   value: string
   footprint: string
+  quantity: number
+  ftype?: string
   supplier_part_number_columns?: Partial<
     Record<SupplierPartNumberColumn, string>
   >
@@ -84,6 +86,8 @@ export const convertCircuitJsonToBomRows = async ({
       comment: isDoNotPlace ? "DNP" : comment,
       value: isDoNotPlace ? "DNP" : comment,
       footprint: part_info.footprint || "",
+      quantity: 1,
+      ftype: source_component.ftype,
       supplier_part_number_columns: isDoNotPlace
         ? undefined
         : (part_info.supplier_part_number_columns ??
@@ -95,7 +99,39 @@ export const convertCircuitJsonToBomRows = async ({
     })
   }
 
-  return bom
+  // Group identical components
+  const groupedBom: BomRow[] = []
+  const groupMap = new Map<string, BomRow[]>()
+
+  for (const row of bom) {
+    const key = JSON.stringify({
+      comment: row.comment,
+      value: row.value,
+      footprint: row.footprint,
+      ftype: row.ftype,
+      supplier_part_number_columns: row.supplier_part_number_columns,
+      manufacturer_mpn_pairs: row.manufacturer_mpn_pairs,
+      extra_columns: row.extra_columns,
+    })
+
+    if (!groupMap.has(key)) {
+      groupMap.set(key, [])
+    }
+    groupMap.get(key)!.push(row)
+  }
+
+  for (const group of groupMap.values()) {
+    const first = group[0]
+    const designators = group.map((r) => r.designator).sort()
+    const designator = designators.join(",")
+    groupedBom.push({
+      ...first,
+      designator,
+      quantity: group.length,
+    })
+  }
+
+  return groupedBom
 }
 
 function convertSupplierPartNumbersIntoColumns(
@@ -139,6 +175,7 @@ export const convertBomRowsToCsv = (bom_rows: BomRow[]): string => {
       Comment: row.comment,
       Value: row.value,
       Footprint: row.footprint,
+      Quantity: row.quantity,
       ...supplier_part_number_columns,
     }
   })
@@ -148,6 +185,7 @@ export const convertBomRowsToCsv = (bom_rows: BomRow[]): string => {
     "Comment",
     "Value",
     "Footprint",
+    "Quantity",
   ]
   for (const row of csv_data) {
     for (const key in row) {

--- a/tests/get-bom-for-nine-key-keyboard.test.ts
+++ b/tests/get-bom-for-nine-key-keyboard.test.ts
@@ -8,31 +8,34 @@ test("get-bom-for-nine-key-keyboard", async () => {
   })
 
   // Check microcontroller
-  const microcontroller = bomRows.find((row) => row.designator === "U1")
+  const microcontroller = bomRows.find((row) => row.designator.includes("U1"))
   expect(microcontroller).toBeDefined()
   expect(microcontroller?.comment).toBe("")
   expect(microcontroller?.value).toBe("")
+  expect(microcontroller?.quantity).toBe(10)
 
-  // Check a key
-  const key = bomRows.find((row) => row.designator === "K1")
+  // Check keys (grouped)
+  const key = bomRows.find((row) => row.designator.includes("K1") && !row.designator.includes("_shaft"))
   expect(key).toBeDefined()
   expect(key?.comment).toBe("")
   expect(key?.value).toBe("")
+  expect(key?.quantity).toBe(9)
   expect(key?.supplier_part_number_columns).toBeDefined()
   expect(key?.supplier_part_number_columns?.["JLCPCB Part #"]).toBe("C5184526")
 
-  // Check a diode
-  const diode = bomRows.find((row) => row.designator === "D1")
+  // Check diodes (grouped)
+  const diode = bomRows.find((row) => row.designator.includes("D1"))
   expect(diode).toBeDefined()
   expect(diode?.comment).toBe("")
   expect(diode?.value).toBe("")
+  expect(diode?.quantity).toBe(9)
   expect(diode?.supplier_part_number_columns).toBeDefined()
   expect(diode?.supplier_part_number_columns?.["JLCPCB Part #"]).toBe("C57759")
 
   // Convert to CSV
   const csv = convertBomRowsToCsv(bomRows)
-  expect(csv).toContain("Designator,Comment,Value,Footprint,JLCPCB Part #")
-  expect(csv).toContain("U1,,,,")
-  expect(csv).toContain("K1,,,,C5184526")
-  expect(csv).toContain("D1,,,,C57759")
+  expect(csv).toContain("Designator,Comment,Value,Footprint,Quantity,JLCPCB Part #")
+  expect(csv).toContain("\"K1_shaft,K2_shaft,K3_shaft,K4_shaft,K5_shaft,K6_shaft,K7_shaft,K8_shaft,K9_shaft,U1\",,,,10,")
+  expect(csv).toContain("\"K1,K2,K3,K4,K5,K6,K7,K8,K9\",,,,9,C5184526")
+  expect(csv).toContain("\"D1,D2,D3,D4,D5,D6,D7,D8,D9\",,,,9,C57759")
 })

--- a/tests/get-bom-for-nine-key-keyboard.test.ts
+++ b/tests/get-bom-for-nine-key-keyboard.test.ts
@@ -8,30 +8,27 @@ test("get-bom-for-nine-key-keyboard", async () => {
   })
 
   // Check microcontroller
-  const microcontroller = bomRows.find((row) => row.designator.includes("U1"))
+  const microcontroller = bomRows.find((row) => row.designator === "U1")
   expect(microcontroller).toBeDefined()
   expect(microcontroller?.comment).toBe("")
   expect(microcontroller?.value).toBe("")
-  expect(microcontroller?.quantity).toBe(10)
+  expect(microcontroller?.quantity).toBe(1)
 
-  // Check keys (grouped)
-  const key = bomRows.find(
-    (row) =>
-      row.designator.includes("K1") && !row.designator.includes("_shaft"),
-  )
+  // Check a key
+  const key = bomRows.find((row) => row.designator === "K1")
   expect(key).toBeDefined()
   expect(key?.comment).toBe("")
   expect(key?.value).toBe("")
-  expect(key?.quantity).toBe(9)
+  expect(key?.quantity).toBe(1)
   expect(key?.supplier_part_number_columns).toBeDefined()
   expect(key?.supplier_part_number_columns?.["JLCPCB Part #"]).toBe("C5184526")
 
-  // Check diodes (grouped)
-  const diode = bomRows.find((row) => row.designator.includes("D1"))
+  // Check a diode
+  const diode = bomRows.find((row) => row.designator === "D1")
   expect(diode).toBeDefined()
   expect(diode?.comment).toBe("")
   expect(diode?.value).toBe("")
-  expect(diode?.quantity).toBe(9)
+  expect(diode?.quantity).toBe(1)
   expect(diode?.supplier_part_number_columns).toBeDefined()
   expect(diode?.supplier_part_number_columns?.["JLCPCB Part #"]).toBe("C57759")
 
@@ -40,9 +37,7 @@ test("get-bom-for-nine-key-keyboard", async () => {
   expect(csv).toContain(
     "Designator,Comment,Value,Footprint,Quantity,JLCPCB Part #",
   )
-  expect(csv).toContain(
-    '"K1_shaft,K2_shaft,K3_shaft,K4_shaft,K5_shaft,K6_shaft,K7_shaft,K8_shaft,K9_shaft,U1",,,,10,',
-  )
-  expect(csv).toContain('"K1,K2,K3,K4,K5,K6,K7,K8,K9",,,,9,C5184526')
-  expect(csv).toContain('"D1,D2,D3,D4,D5,D6,D7,D8,D9",,,,9,C57759')
+  expect(csv).toContain("U1,,,,1,")
+  expect(csv).toContain("K1,,,,1,C5184526")
+  expect(csv).toContain("D1,,,,1,C57759")
 })

--- a/tests/get-bom-for-nine-key-keyboard.test.ts
+++ b/tests/get-bom-for-nine-key-keyboard.test.ts
@@ -15,7 +15,10 @@ test("get-bom-for-nine-key-keyboard", async () => {
   expect(microcontroller?.quantity).toBe(10)
 
   // Check keys (grouped)
-  const key = bomRows.find((row) => row.designator.includes("K1") && !row.designator.includes("_shaft"))
+  const key = bomRows.find(
+    (row) =>
+      row.designator.includes("K1") && !row.designator.includes("_shaft"),
+  )
   expect(key).toBeDefined()
   expect(key?.comment).toBe("")
   expect(key?.value).toBe("")
@@ -34,8 +37,12 @@ test("get-bom-for-nine-key-keyboard", async () => {
 
   // Convert to CSV
   const csv = convertBomRowsToCsv(bomRows)
-  expect(csv).toContain("Designator,Comment,Value,Footprint,Quantity,JLCPCB Part #")
-  expect(csv).toContain("\"K1_shaft,K2_shaft,K3_shaft,K4_shaft,K5_shaft,K6_shaft,K7_shaft,K8_shaft,K9_shaft,U1\",,,,10,")
-  expect(csv).toContain("\"K1,K2,K3,K4,K5,K6,K7,K8,K9\",,,,9,C5184526")
-  expect(csv).toContain("\"D1,D2,D3,D4,D5,D6,D7,D8,D9\",,,,9,C57759")
+  expect(csv).toContain(
+    "Designator,Comment,Value,Footprint,Quantity,JLCPCB Part #",
+  )
+  expect(csv).toContain(
+    '"K1_shaft,K2_shaft,K3_shaft,K4_shaft,K5_shaft,K6_shaft,K7_shaft,K8_shaft,K9_shaft,U1",,,,10,',
+  )
+  expect(csv).toContain('"K1,K2,K3,K4,K5,K6,K7,K8,K9",,,,9,C5184526')
+  expect(csv).toContain('"D1,D2,D3,D4,D5,D6,D7,D8,D9",,,,9,C57759')
 })


### PR DESCRIPTION
The BOM CSV generated one row per individual component, with no quantity column or grouping of identical parts. Why quantity is important: In a Bill of Materials (BOM), the quantity column is crucial because it tells manufacturers, procurement teams, and assemblers exactly how many of each unique component are needed for the design. Without it, users must manually count rows to determine procurement quantities, which is error-prone and inefficient for production.

To reproduce and demonstrate this issue, I created a temporary reproduce.ts script that loaded the test circuit JSON and generated the BOM CSV, showing the problematic output with individual rows and no quantity information.

Designator,Comment,Value,Footprint,JLCPCB Part #
U1,,,,
K1,,,,C5184526
K1_shaft,,,,
D1,,,,C57759
K2,,,,C5184526
K2_shaft,,,,
D2,,,,C57759
K3,,,,C5184526
K3_shaft,,,,
D3,,,,C57759
K4,,,,C5184526
K4_shaft,,,,
D4,,,,C57759
K5,,,,C5184526
K5_shaft,,,,
D5,,,,C57759
K6,,,,C5184526
K6_shaft,,,,
D6,,,,C57759
K7,,,,C5184526
K7_shaft,,,,
D7,,,,C57759
K8,,,,C5184526
K8_shaft,,,,
D8,,,,C57759
K9,,,,C5184526
K9_shaft,,,,
D9,,,,C57759
<img width="1012" height="592" alt="Screenshot 2025-12-11 at 11 04 55 AM" src="https://github.com/user-attachments/assets/3cd559ff-1939-4f72-8a51-cc2cd20951d2" />
Total rows: 28 (1 microcontroller + 9 keys + 9 key shafts + 9 diodes)
No quantity information: Each component implicitly has quantity 1
No grouping: Identical parts (e.g., all keys with the same JLCPCB part #) are listed separately

After the Fix
The BOM CSV now includes a "Quantity" column and groups identical components:
Designator,Comment,Value,Footprint,Quantity,JLCPCB Part #
"K1_shaft,K2_shaft,K3_shaft,K4_shaft,K5_shaft,K6_shaft,K7_shaft,K8_shaft,K9_shaft,U1",,,,10,
"K1,K2,K3,K4,K5,K6,K7,K8,K9",,,,9,C5184526
"D1,D2,D3,D4,D5,D6,D7,D8,D9",,,,9,C57759

<img width="1012" height="206" alt="Screenshot 2025-12-11 at 11 11 25 AM" src="https://github.com/user-attachments/assets/59360b77-2f15-4d28-945b-94d717420324" />

Total rows: 3 (grouped by identical part specifications)
Quantity column added: Shows the count of each unique part
Grouped components:
Key shafts and microcontroller (both "simple_chip" with no supplier info): 10 total
Keys (all identical with JLCPCB part # C5184526): 9 total
Diodes (all identical with JLCPCB part # C57759): 9 total
Designators combined: Listed as comma-separated values for grouped parts
This resolves the issue by providing clear quantity information and following standard BOM practices for component consolidation. 

/fix #8 
