### PR TITLE
Fix BOM export to include footprints from CAD components

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -63,6 +63,10 @@ export const convertCircuitJsonToBomRows = async ({
         e.type === "source_component" &&
         e.source_component_id === elm.source_component_id,
     ) as any as SourceComponentBase
+    const cad_component = circuitJson.find(
+      (e) =>
+        e.type === "cad_component" && e.pcb_component_id === elm.pcb_component_id,
+    ) as any
 
     if (!source_component) continue
 
@@ -83,7 +87,7 @@ export const convertCircuitJsonToBomRows = async ({
       designator: source_component.name ?? elm.pcb_component_id,
       comment: isDoNotPlace ? "DNP" : comment,
       value: isDoNotPlace ? "DNP" : comment,
-      footprint: part_info.footprint || "",
+      footprint: part_info.footprint || cad_component?.footprinter_string || "",
       supplier_part_number_columns: isDoNotPlace
         ? undefined
         : (part_info.supplier_part_number_columns ??

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -65,7 +65,8 @@ export const convertCircuitJsonToBomRows = async ({
     ) as any as SourceComponentBase
     const cad_component = circuitJson.find(
       (e) =>
-        e.type === "cad_component" && e.pcb_component_id === elm.pcb_component_id,
+        e.type === "cad_component" &&
+        e.pcb_component_id === elm.pcb_component_id,
     ) as any
 
     if (!source_component) continue

--- a/tests/get-bom-for-nine-key-keyboard.test.ts
+++ b/tests/get-bom-for-nine-key-keyboard.test.ts
@@ -12,12 +12,14 @@ test("get-bom-for-nine-key-keyboard", async () => {
   expect(microcontroller).toBeDefined()
   expect(microcontroller?.comment).toBe("")
   expect(microcontroller?.value).toBe("")
+  expect(microcontroller?.footprint).toBe("soic40_w22.58mm_p2.54mm_pl3.8_ph2.2")
 
   // Check a key
   const key = bomRows.find((row) => row.designator === "K1")
   expect(key).toBeDefined()
   expect(key?.comment).toBe("")
   expect(key?.value).toBe("")
+  expect(key?.footprint).toBe("")
   expect(key?.supplier_part_number_columns).toBeDefined()
   expect(key?.supplier_part_number_columns?.["JLCPCB Part #"]).toBe("C5184526")
 
@@ -26,13 +28,14 @@ test("get-bom-for-nine-key-keyboard", async () => {
   expect(diode).toBeDefined()
   expect(diode?.comment).toBe("")
   expect(diode?.value).toBe("")
+  expect(diode?.footprint).toBe("")
   expect(diode?.supplier_part_number_columns).toBeDefined()
   expect(diode?.supplier_part_number_columns?.["JLCPCB Part #"]).toBe("C57759")
 
   // Convert to CSV
   const csv = convertBomRowsToCsv(bomRows)
   expect(csv).toContain("Designator,Comment,Value,Footprint,JLCPCB Part #")
-  expect(csv).toContain("U1,,,,")
+  expect(csv).toContain("U1,,,soic40_w22.58mm_p2.54mm_pl3.8_ph2.2,")
   expect(csv).toContain("K1,,,,C5184526")
   expect(csv).toContain("D1,,,,C57759")
 })


### PR DESCRIPTION
BOM generation was leaving the Footprint column empty unless resolvePart provided it. This change falls back to the matching cad_component.footprinter_string, so standard tscircuit designs export footprints correctly without extra manual steps.

<img width="662" height="294" alt="image" src="https://github.com/user-attachments/assets/b9cf13f9-45f8-440b-a1b8-1bc5f96a52e7" />

<img width="399" height="256" alt="image" src="https://github.com/user-attachments/assets/a43f5e12-c847-4505-813b-8ea118d72a35" />
