### PR TITLE
fix: filter non-placeable components from BOM and populate footprint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "circuit-json-to-bom-csv",
@@ -8,7 +9,7 @@
         "papaparse": "^5.4.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "^1.9.3",
+        "@biomejs/biome": "^1.9.4",
         "@types/bun": "^1.2.2",
         "@types/papaparse": "^5.3.14",
         "circuit-json": "^0.0.265",

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -1,10 +1,10 @@
-import { expect, test, describe } from "bun:test"
-import { convertCircuitJsonToBomRows, convertBomRowsToCsv } from "./index"
+import { describe, expect, test } from "bun:test"
 import type {
   AnyCircuitElement,
   PcbComponent,
   SourceComponentBase,
 } from "circuit-json"
+import { convertBomRowsToCsv, convertCircuitJsonToBomRows } from "./index"
 
 describe("convertCircuitJsonToBomRows", () => {
   test("should convert circuit JSON to BOM rows", async () => {
@@ -32,6 +32,71 @@ describe("convertCircuitJsonToBomRows", () => {
       value: "1k",
       footprint: "",
     })
+  })
+
+  test("should filter out non-placeable components (vias, bare pads)", async () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "pcb_component",
+        pcb_component_id: "pcb_component_1",
+        source_component_id: "source_component_1",
+      } as PcbComponent,
+      {
+        type: "source_component",
+        source_component_id: "source_component_1",
+        name: "R1",
+        ftype: "simple_resistor",
+        resistance: 100,
+      } as SourceComponentBase,
+      {
+        type: "pcb_component",
+        pcb_component_id: "pcb_component_6",
+        source_component_id: "source_component_6",
+      } as PcbComponent,
+      {
+        type: "source_component",
+        source_component_id: "source_component_6",
+        name: "pcb_component_6",
+      } as any,
+      {
+        type: "pcb_component",
+        pcb_component_id: "pcb_component_7",
+        source_component_id: "source_component_7",
+      } as PcbComponent,
+      {
+        type: "source_component",
+        source_component_id: "source_component_7",
+        name: "pcb_component_7",
+      } as any,
+    ] as AnyCircuitElement[]
+
+    const bomRows = await convertCircuitJsonToBomRows({ circuitJson })
+
+    expect(bomRows).toHaveLength(1)
+    expect(bomRows[0].designator).toBe("R1")
+  })
+
+  test("should include footprint from source_component props", async () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "pcb_component",
+        pcb_component_id: "pcb_component_1",
+        source_component_id: "source_component_1",
+      } as PcbComponent,
+      {
+        type: "source_component",
+        source_component_id: "source_component_1",
+        name: "R1",
+        ftype: "simple_resistor",
+        resistance: 56,
+        footprint: "0603",
+      } as any,
+    ] as AnyCircuitElement[]
+
+    const bomRows = await convertCircuitJsonToBomRows({ circuitJson })
+
+    expect(bomRows).toHaveLength(1)
+    expect(bomRows[0].footprint).toBe("0603")
   })
 
   test("should map lcsc to JLCPCB Part # when lcsc is present", async () => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -44,6 +44,32 @@ interface ResolvedPart {
 // Comment Designator Footprint "JLCPCB Part #(optional)"
 // Designator Value Footprint Populate MPN Manufacturer MPN Manufacturer MPN Manufacturer MPN Manufacturer MPN Manufacturer
 
+const NON_PLACEABLE_FTYPES = new Set([
+  "simple_net",
+  "simple_ground",
+  "simple_power",
+])
+
+function isPlaceableComponent(
+  source: SourceComponentBase,
+  pcb: PcbComponent,
+): boolean {
+  if (NON_PLACEABLE_FTYPES.has(source.ftype ?? "")) return false
+
+  const name = source.name ?? pcb.pcb_component_id ?? ""
+  if (/^pcb_component_\d+$/.test(name)) return false
+
+  const hasMeaningfulName =
+    !!source.name && !source.name.startsWith("pcb_component_")
+  const hasFtype = !!source.ftype
+  const hasFootprint =
+    !!(source as any).footprint || !!(source as any).footprinter_string
+
+  if (!hasMeaningfulName && !hasFtype && !hasFootprint) return false
+
+  return true
+}
+
 export const convertCircuitJsonToBomRows = async ({
   circuitJson,
   resolvePart,
@@ -71,6 +97,8 @@ export const convertCircuitJsonToBomRows = async ({
 
     if (!source_component) continue
 
+    if (!isPlaceableComponent(source_component, elm)) continue
+
     const part_info: Partial<ResolvedPart> =
       (await resolvePart?.({ pcb_component: elm, source_component })) ?? {}
 
@@ -88,7 +116,11 @@ export const convertCircuitJsonToBomRows = async ({
       designator: source_component.name ?? elm.pcb_component_id,
       comment: isDoNotPlace ? "DNP" : comment,
       value: isDoNotPlace ? "DNP" : comment,
-      footprint: part_info.footprint || cad_component?.footprinter_string || "",
+      footprint:
+        part_info.footprint ||
+        cad_component?.footprinter_string ||
+        (source_component as any).footprint ||
+        "",
       supplier_part_number_columns: isDoNotPlace
         ? undefined
         : (part_info.supplier_part_number_columns ??


### PR DESCRIPTION
## Summary

Fixes tscircuit/tscircuit#3303 (Bug 1: non-components in BOM + partial Bug 2: empty footprint column)

### Problem

The BOM CSV generated by `tsci export -f gerbers` includes rows for vias, bare-copper edge pads, and other non-placeable `pcb_component` entries. Additionally, the `Footprint` column is empty even when `source_component.footprint` is set in the JSX.

### Changes

1. **Filter non-placeable components** via new `isPlaceableComponent()` helper:
   - Skips components with ftype in simple_net, simple_ground, simple_power
   - Skips auto-generated names matching pcb_component_N (vias, bare structures)
   - Skips entries with no meaningful name, no ftype, and no footprint

2. **Populate footprint from source_component**: Falls back to source_component.footprint when cad_component.footprinter_string is unavailable.

### Tests

- Added test: non-placeable components (vias, bare pads) are filtered out
- Added test: footprint field populated from source_component props
- All 6 existing + new tests pass