### PR TITLE
Add quantity support to BOM CSV output

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -1,10 +1,10 @@
-import { expect, test, describe } from "bun:test"
-import { convertCircuitJsonToBomRows, convertBomRowsToCsv } from "./index"
+import { describe, expect, test } from "bun:test"
 import type {
   AnyCircuitElement,
   PcbComponent,
   SourceComponentBase,
 } from "circuit-json"
+import { convertBomRowsToCsv, convertCircuitJsonToBomRows } from "./index"
 
 describe("convertCircuitJsonToBomRows", () => {
   test("should convert circuit JSON to BOM rows", async () => {
@@ -28,6 +28,7 @@ describe("convertCircuitJsonToBomRows", () => {
     expect(bomRows).toHaveLength(1)
     expect(bomRows[0]).toEqual({
       designator: "R1",
+      quantity: 1,
       comment: "1k",
       value: "1k",
       footprint: "",
@@ -61,9 +62,69 @@ describe("convertCircuitJsonToBomRows", () => {
     const bomRowsFromJson = await convertCircuitJsonToBomRows({ circuitJson })
     const csv = convertBomRowsToCsv(bomRowsFromJson)
     expect(csv).toMatchInlineSnapshot(`
-      "Designator,Comment,Value,Footprint,JLCPCB Part #
-      C1,10µ,10µ,,C12345"
+      "Designator,Quantity,Comment,Value,Footprint,JLCPCB Part #
+      C1,1,10µ,10µ,,C12345"
     `)
+  })
+
+  test("should combine matching parts and count quantity", async () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "pcb_component",
+        pcb_component_id: "pcb_component_1",
+        source_component_id: "source_component_1",
+      } as PcbComponent,
+      {
+        type: "pcb_component",
+        pcb_component_id: "pcb_component_2",
+        source_component_id: "source_component_2",
+      } as PcbComponent,
+      {
+        type: "cad_component",
+        pcb_component_id: "pcb_component_1",
+        footprinter_string: "res0603",
+      },
+      {
+        type: "cad_component",
+        pcb_component_id: "pcb_component_2",
+        footprinter_string: "res0603",
+      },
+      {
+        type: "source_component",
+        source_component_id: "source_component_1",
+        name: "R1",
+        ftype: "simple_resistor",
+        resistance: 22,
+        supplier_part_numbers: {
+          jlcpcb: ["C23345"],
+        },
+      } as SourceComponentBase,
+      {
+        type: "source_component",
+        source_component_id: "source_component_2",
+        name: "R2",
+        ftype: "simple_resistor",
+        resistance: 22,
+        supplier_part_numbers: {
+          jlcpcb: ["C23345"],
+        },
+      } as SourceComponentBase,
+    ] as AnyCircuitElement[]
+
+    const bomRows = await convertCircuitJsonToBomRows({ circuitJson })
+
+    expect(bomRows).toEqual([
+      {
+        designator: "R1, R2",
+        quantity: 2,
+        comment: "22",
+        value: "22",
+        footprint: "res0603",
+        supplier_part_number_columns: {
+          "JLCPCB Part #": "C23345",
+        },
+      },
+    ])
   })
 })
 
@@ -84,8 +145,8 @@ describe("convertBomRowsToCsv", () => {
     const csv = convertBomRowsToCsv(bomRows)
 
     expect(csv).toMatchInlineSnapshot(`
-      "Designator,Comment,Value,Footprint,JLCPCB Part #
-      R1,1k,1k,0805,C17513"
+      "Designator,Quantity,Comment,Value,Footprint,JLCPCB Part #
+      R1,1,1k,1k,0805,C17513"
     `)
   })
 })

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,6 +15,7 @@ type SupplierPartNumberColumn = "JLCPCB Part #"
 
 interface BomRow {
   designator: string
+  quantity?: number
   comment: string
   value: string
   footprint: string
@@ -86,6 +87,7 @@ export const convertCircuitJsonToBomRows = async ({
     bom.push({
       // TODO, use designator from source_component when it's introduced
       designator: source_component.name ?? elm.pcb_component_id,
+      quantity: 1,
       comment: isDoNotPlace ? "DNP" : comment,
       value: isDoNotPlace ? "DNP" : comment,
       footprint: part_info.footprint || cad_component?.footprinter_string || "",
@@ -100,7 +102,47 @@ export const convertCircuitJsonToBomRows = async ({
     })
   }
 
-  return bom
+  return combineBomRows(bom)
+}
+
+function combineBomRows(bom_rows: BomRow[]): BomRow[] {
+  const combinedRows = new Map<string, BomRow>()
+
+  for (const row of bom_rows) {
+    const key = getBomRowPartKey(row)
+    const existingRow = combinedRows.get(key)
+
+    if (existingRow) {
+      existingRow.designator = `${existingRow.designator}, ${row.designator}`
+      existingRow.quantity = (existingRow.quantity ?? 1) + (row.quantity ?? 1)
+      continue
+    }
+
+    combinedRows.set(key, { ...row })
+  }
+
+  return Array.from(combinedRows.values())
+}
+
+function getBomRowPartKey(row: BomRow): string {
+  return JSON.stringify({
+    comment: row.comment,
+    value: row.value,
+    footprint: row.footprint,
+    supplier_part_number_columns: sortRecord(row.supplier_part_number_columns),
+    manufacturer_mpn_pairs: row.manufacturer_mpn_pairs,
+    extra_columns: sortRecord(row.extra_columns),
+  })
+}
+
+function sortRecord<T extends string | undefined>(
+  record: Partial<Record<string, T>> | undefined,
+): Partial<Record<string, T>> | undefined {
+  if (!record) return undefined
+
+  return Object.fromEntries(
+    Object.entries(record).sort(([keyA], [keyB]) => keyA.localeCompare(keyB)),
+  )
 }
 
 function convertSupplierPartNumbersIntoColumns(
@@ -141,6 +183,7 @@ export const convertBomRowsToCsv = (bom_rows: BomRow[]): string => {
 
     return {
       Designator: row.designator,
+      Quantity: row.quantity ?? 1,
       Comment: row.comment,
       Value: row.value,
       Footprint: row.footprint,
@@ -150,6 +193,7 @@ export const convertBomRowsToCsv = (bom_rows: BomRow[]): string => {
 
   const columnHeaders: string[] = [
     "Designator",
+    "Quantity",
     "Comment",
     "Value",
     "Footprint",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -102,10 +102,10 @@ export const convertCircuitJsonToBomRows = async ({
     })
   }
 
-  return combineBomRows(bom)
+  return groupBomRowsByPart(bom)
 }
 
-function combineBomRows(bom_rows: BomRow[]): BomRow[] {
+function groupBomRowsByPart(bom_rows: BomRow[]): BomRow[] {
   const combinedRows = new Map<string, BomRow>()
 
   for (const row of bom_rows) {

--- a/tests/get-bom-for-nine-key-keyboard.test.ts
+++ b/tests/get-bom-for-nine-key-keyboard.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test"
-import { convertCircuitJsonToBomRows, convertBomRowsToCsv } from "../lib/index"
+import { expect, test } from "bun:test"
+import { convertBomRowsToCsv, convertCircuitJsonToBomRows } from "../lib/index"
 import nineKeyKeyboardCircuitJson from "./assets/nine-key-keyboard.json"
 
 test("get-bom-for-nine-key-keyboard", async () => {
@@ -15,8 +15,9 @@ test("get-bom-for-nine-key-keyboard", async () => {
   expect(microcontroller?.footprint).toBe("soic40_w22.58mm_p2.54mm_pl3.8_ph2.2")
 
   // Check a key
-  const key = bomRows.find((row) => row.designator === "K1")
+  const key = bomRows.find((row) => row.designator.includes("K1"))
   expect(key).toBeDefined()
+  expect(key?.quantity).toBe(9)
   expect(key?.comment).toBe("")
   expect(key?.value).toBe("")
   expect(key?.footprint).toBe("")
@@ -24,8 +25,9 @@ test("get-bom-for-nine-key-keyboard", async () => {
   expect(key?.supplier_part_number_columns?.["JLCPCB Part #"]).toBe("C5184526")
 
   // Check a diode
-  const diode = bomRows.find((row) => row.designator === "D1")
+  const diode = bomRows.find((row) => row.designator.includes("D1"))
   expect(diode).toBeDefined()
+  expect(diode?.quantity).toBe(9)
   expect(diode?.comment).toBe("")
   expect(diode?.value).toBe("")
   expect(diode?.footprint).toBe("")
@@ -34,8 +36,10 @@ test("get-bom-for-nine-key-keyboard", async () => {
 
   // Convert to CSV
   const csv = convertBomRowsToCsv(bomRows)
-  expect(csv).toContain("Designator,Comment,Value,Footprint,JLCPCB Part #")
-  expect(csv).toContain("U1,,,soic40_w22.58mm_p2.54mm_pl3.8_ph2.2,")
-  expect(csv).toContain("K1,,,,C5184526")
-  expect(csv).toContain("D1,,,,C57759")
+  expect(csv).toContain(
+    "Designator,Quantity,Comment,Value,Footprint,JLCPCB Part #",
+  )
+  expect(csv).toContain("U1,1,,,soic40_w22.58mm_p2.54mm_pl3.8_ph2.2,")
+  expect(csv).toContain('"K1, K2, K3, K4, K5, K6, K7, K8, K9",9,,,,C5184526')
+  expect(csv).toContain('"D1, D2, D3, D4, D5, D6, D7, D8, D9",9,,,,C57759')
 })


### PR DESCRIPTION
## Summary

Adds real quantity support to BOM generation by grouping identical components into a single BOM row and counting them.

## What changed

- Groups matching BOM rows by value, footprint, supplier part number, manufacturer info, and extra columns
- Joins designators like `R_USB_DP, R_USB_DM`
- Adds a `Quantity` CSV column with the grouped count
- Keeps manual BOM rows compatible by defaulting missing quantity to `1`
- Updates tests for grouped switches, diodes, and matching resistor parts

## Verification

- `bun test`
- `bun run build`
- `bunx biome check lib/index.ts lib/index.test.ts tests/get-bom-for-nine-key-keyboard.test.ts`