### PR TITLE
fix: filter non-placeable components from BOM CSV, add footprint fallback

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -63,7 +63,7 @@ function isPlaceableComponent(
     !!source.name && !source.name.startsWith("pcb_component_")
   const hasFtype = !!(source as any).ftype
   const hasFootprint =
-    !!((source as any).footprint) || !!((source as any).footprinter_string)
+    !!(source as any).footprint || !!(source as any).footprinter_string
 
   if (!hasMeaningfulName && !hasFtype && !hasFootprint) return false
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -44,6 +44,32 @@ interface ResolvedPart {
 // Comment Designator Footprint "JLCPCB Part #(optional)"
 // Designator Value Footprint Populate MPN Manufacturer MPN Manufacturer MPN Manufacturer MPN Manufacturer MPN Manufacturer
 
+const NON_PLACEABLE_FTYPES = new Set([
+  "simple_net",
+  "simple_ground",
+  "simple_power",
+])
+
+function isPlaceableComponent(
+  source: SourceComponentBase,
+  pcb: PcbComponent,
+): boolean {
+  if (NON_PLACEABLE_FTYPES.has((source as any).ftype ?? "")) return false
+
+  const name = source.name ?? pcb.pcb_component_id ?? ""
+  if (/^pcb_component_\d+$/.test(name)) return false
+
+  const hasMeaningfulName =
+    !!source.name && !source.name.startsWith("pcb_component_")
+  const hasFtype = !!(source as any).ftype
+  const hasFootprint =
+    !!((source as any).footprint) || !!((source as any).footprinter_string)
+
+  if (!hasMeaningfulName && !hasFtype && !hasFootprint) return false
+
+  return true
+}
+
 export const convertCircuitJsonToBomRows = async ({
   circuitJson,
   resolvePart,
@@ -70,6 +96,7 @@ export const convertCircuitJsonToBomRows = async ({
     ) as any
 
     if (!source_component) continue
+    if (!isPlaceableComponent(source_component, elm)) continue
 
     const part_info: Partial<ResolvedPart> =
       (await resolvePart?.({ pcb_component: elm, source_component })) ?? {}
@@ -88,7 +115,11 @@ export const convertCircuitJsonToBomRows = async ({
       designator: source_component.name ?? elm.pcb_component_id,
       comment: isDoNotPlace ? "DNP" : comment,
       value: isDoNotPlace ? "DNP" : comment,
-      footprint: part_info.footprint || cad_component?.footprinter_string || "",
+      footprint:
+        part_info.footprint ||
+        cad_component?.footprinter_string ||
+        (source_component as any).footprint ||
+        "",
       supplier_part_number_columns: isDoNotPlace
         ? undefined
         : (part_info.supplier_part_number_columns ??


### PR DESCRIPTION
Fixes tscircuit/tscircuit#3303

Adds \isPlaceableComponent()\ filter to exclude vias, bare-copper pads, and auto-generated entries from BOM CSV output. Also adds \source_component.footprint\ as a fallback for the Footprint column.

/claim #3303