### PR TITLE
Exclude copper-pad-only components from BOM rows

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -169,6 +169,35 @@ describe("convertCircuitJsonToBomRows", () => {
     expect(bomRows[0]?.designator).toBe("R1")
     expect(bomRows.some((row) => row.designator === "TP1")).toBe(false)
   })
+
+  test("should skip copper-pad-only components", async () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "pcb_component",
+        pcb_component_id: "pcb_component_1",
+        source_component_id: "source_component_1",
+      } as PcbComponent,
+      {
+        type: "source_component",
+        source_component_id: "source_component_1",
+        name: "SW1",
+        ftype: "simple_chip",
+        supplier_part_numbers: {},
+      } as SourceComponentBase,
+      {
+        type: "cad_component",
+        cad_component_id: "cad_component_1",
+        pcb_component_id: "pcb_component_1",
+        source_component_id: "source_component_1",
+        show_as_bounding_box: true,
+      },
+    ] as AnyCircuitElement[]
+
+    const bomRows = await convertCircuitJsonToBomRows({ circuitJson })
+
+    expect(bomRows).toHaveLength(0)
+    expect(bomRows.some((row) => row.designator === "SW1")).toBe(false)
+  })
 })
 
 describe("convertBomRowsToCsv", () => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -133,6 +133,9 @@ export const convertCircuitJsonToBomRows = async ({
     )
     const trimmedValue = trimText(value)
 
+    if (cad_component?.show_as_bounding_box && !footprint && !jlcpcbPartNumber)
+      continue
+
     bom.push({
       // TODO, use designator from source_component when it's introduced
       designator: trimText(source_component.name ?? elm.pcb_component_id),


### PR DESCRIPTION
### Motivation
- Copper-pad-only components are PCB features, not parts to purchase or assemble.


here SW1 just a copper pad but that included in the csv : 

<img width="717" height="340" alt="image" src="https://github.com/user-attachments/assets/843d63e6-ea55-4d8c-9480-cff5ab305f33" />
