### PR TITLE
skip do-not-place parts in bom

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -102,6 +102,28 @@ describe("convertCircuitJsonToBomRows", () => {
     })
   })
 
+  test("should skip do-not-place components", async () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "pcb_component",
+        pcb_component_id: "pcb_component_1",
+        source_component_id: "source_component_1",
+        do_not_place: true,
+      } as PcbComponent,
+      {
+        type: "source_component",
+        source_component_id: "source_component_1",
+        name: "J1",
+        ftype: "simple_resistor",
+        resistance: 1000,
+      } as SourceComponentBase,
+    ] as AnyCircuitElement[]
+
+    const bomRows = await convertCircuitJsonToBomRows({ circuitJson })
+
+    expect(bomRows).toHaveLength(0)
+  })
+
   test("should use manufacturer part number in comment when available", async () => {
     const circuitJson: AnyCircuitElement[] = [
       {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -84,6 +84,7 @@ export const convertCircuitJsonToBomRows = async ({
   const bom: BomRow[] = []
   for (const elm of circuitJson) {
     if (elm.type !== "pcb_component") continue
+    if (elm.do_not_place) continue
 
     const source_component = circuitJson.find(
       (e) =>


### PR DESCRIPTION
### Motivation
- Do-not-place components should not appear in assembly BOM exports.

### Before
- Do-not-place components were emitted as DNP rows.

### After
- Do-not-place components are omitted before part resolution and BOM row creation.